### PR TITLE
Fixed hex color handeling in Map and Timeline Slider

### DIFF
--- a/frontend/src/components/map/Map.jsx
+++ b/frontend/src/components/map/Map.jsx
@@ -233,7 +233,7 @@ const MapComponent = ({ selectedDate, zoom }) => {
           event.halls ? event.halls.split(", ").includes(hall.name) : false
         );
         const status = event ? getEventStatus(event, selectedDate) : "unknown";
-        const fillColor = event ? `#${event.event_color}` : "gray";
+        const fillColor = event ? `${event.event_color}` : "gray";
         const opacity = event ? getPolygonOpacity(status) : 0.9;
 
         return (
@@ -274,7 +274,7 @@ const MapComponent = ({ selectedDate, zoom }) => {
             : false
         );
         const status = event ? getEventStatus(event, selectedDate) : "unknown";
-        const fillColor = event ? `#${event.event_color}` : "gray";
+        const fillColor = event ? `${event.event_color}` : "gray";
         const opacity = event ? getPolygonOpacity(status) : 0.9;
         const popupOffset = downwardsOverlays.includes(entrance.name)
           ? [0, 50]
@@ -320,7 +320,7 @@ const MapComponent = ({ selectedDate, zoom }) => {
             : false
         );
         const status = event ? getEventStatus(event, selectedDate) : "unknown";
-        const fillColor = event ? `#${event.event_color}` : "gray";
+        const fillColor = event ? `${event.event_color}` : "gray";
         const opacity = event ? getPolygonOpacity(status) : 0.9;
         const popupOffset = downwardsOverlays.includes(parkingLot.name)
           ? [0, 80]

--- a/frontend/src/components/map/TimelineSlider.jsx
+++ b/frontend/src/components/map/TimelineSlider.jsx
@@ -67,7 +67,7 @@ const TimelineSlider = ({ selectedDate, setSelectedDate }) => {
 
         const rows = [];
         eventsData.forEach((event) => {
-          event.event_color = `#${event.event_color}`; // Add this line to prepend '#'
+          event.event_color = `${event.event_color}`; // Add this line to prepend '#'
           const eventStart = dayjs(event.assembly_start_date).format(
             "YYYY-MM-DD"
           );


### PR DESCRIPTION
**Fixed Hex Color Handling:** 
Updated the storage format for hex colors in the database to ensure they are saved with a leading #000000 format instead of 000000. This standardizes the hex color format across the application, preventing potential issues with color rendering and consistency.