### PR TITLE
Fix #85 to not allow adding parking spaces without names

### DIFF
--- a/frontend/src/components/parking_space/AddParkingSpace.jsx
+++ b/frontend/src/components/parking_space/AddParkingSpace.jsx
@@ -100,6 +100,7 @@ const AddParkingSpace = () => {
                 fullWidth
                 error={!!error}
                 helperText={error}
+                required={true}
               />
             </Box>
           </FormControl>


### PR DESCRIPTION
Hello @NickSchitt2510,

thanks for the observation. I quickly fixed the bug. 

<img width="1316" alt="Screenshot 2024-06-25 at 00 34 20" src="https://github.com/schwarzjakob/southpark/assets/67920915/8b5df767-a87d-4a0f-901f-9d44a0da3065">
