### PR TITLE
Add media query for timeline slider

### DIFF
--- a/frontend/src/components/map/TimelineSlider.jsx
+++ b/frontend/src/components/map/TimelineSlider.jsx
@@ -387,30 +387,9 @@ const TimelineSlider = ({ selectedDate, setSelectedDate, selectedEventId }) => {
                   bgcolor: theme.palette.background.paper,
                   height: `${eventRows.length * ROW_HEIGHT + OFFSET}px`,
                   position: "absolute",
-                  left: `calc(-${BUFFER * 45 + 30}px - ${
-                    selectedEventId ? "135px" : "45px"
-                  })`,
+                  left: "50%",
+                  transform: `translateX(calc(-50% - 22.5px))`,
                   transition: "left 0.3s ease-in-out",
-                  "@media (min-width: 1500px)": {
-                    left: `calc(-${BUFFER * 45 + 30}px - ${
-                      selectedEventId ? "335px" : "105px"
-                    })`,
-                  },
-                  "@media (min-width: 2000px)": {
-                    left: `calc(-${BUFFER * 45 + 30}px - ${
-                      selectedEventId ? "735px" : "105px"
-                    })`,
-                  },
-                  "@media (min-width: 2500px)": {
-                    left: `calc(-${BUFFER * 45 + 30}px - ${
-                      selectedEventId ? "935px" : "105px"
-                    })`,
-                  },
-                  "@media (min-width: 3000px)": {
-                    left: `calc(-${BUFFER * 45 + 30}px - ${
-                      selectedEventId ? "1135px" : "105px"
-                    })`,
-                  },
                 }}
               >
                 {days.map((day) => (


### PR DESCRIPTION
This bugfix address the issue where selected day (blue column) gets out of timeline slider container when the width of user's window is larger than 1500px in both map view and event detail page.

![Screenshot 2024-06-29 at 1 47 24 PM](https://github.com/schwarzjakob/southpark/assets/121604402/19bde94c-8a13-42e1-bfb7-5b5c21ea0b9f)

Now it's fixed by adding media query to the timeline container.