### PR TITLE
Add Refresh Login Token Logic to Avoid /auth/user Console Error

### DIFF
--- a/frontend/src/components/auth/Login.jsx
+++ b/frontend/src/components/auth/Login.jsx
@@ -7,6 +7,7 @@ import {
   Typography,
   Box,
   Alert,
+  CircularProgress,
 } from "@mui/material";
 import axios from "axios";
 import LoginRoundedIcon from "@mui/icons-material/LoginRounded";
@@ -18,6 +19,7 @@ const Login = () => {
   const [message, setMessage] = useState(null);
   const [severity, setSeverity] = useState("success");
   const [clientIp, setClientIp] = useState("");
+  const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -37,6 +39,7 @@ const Login = () => {
 
   const handleSubmit = async (event) => {
     event.preventDefault();
+    setLoading(true);
     try {
       const response = await axios.post("/api/auth/login", {
         identifier: identifier.trim(),
@@ -46,17 +49,18 @@ const Login = () => {
       const { token } = response.data;
       sessionStorage.setItem("token", token);
       localStorage.setItem("auth", "true");
-      console.log("Login successful");
-      window.dispatchEvent(new Event("authChange"));
       setMessage("Login Successful");
       setSeverity("success");
+      window.dispatchEvent(new Event("authChange"));
 
-      const initialPath = location.state?.from?.pathname || "/";
-      navigate(initialPath, { replace: true });
+      setTimeout(() => {
+        const initialPath = location.state?.from?.pathname || "/";
+        navigate(initialPath, { replace: true });
+      }, 1000);
     } catch (error) {
       setMessage(error.response.data.message || "Invalid credentials");
       setSeverity("error");
-      console.log("Invalid credentials");
+      setLoading(false);
     }
   };
 
@@ -71,46 +75,51 @@ const Login = () => {
         </Box>
 
         {message && <Alert severity={severity}>{message}</Alert>}
-        <form onSubmit={handleSubmit}>
-          <TextField
-            label="Username or Email"
-            variant="outlined"
-            fullWidth
-            margin="normal"
-            value={identifier}
-            onChange={(e) => setIdentifier(e.target.value)}
-            autoComplete="username email"
-          />
-          <TextField
-            label="Password"
-            type="password"
-            variant="outlined"
-            fullWidth
-            margin="normal"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            autoComplete="current-password"
-          />
-          <Button
-            className="login-submit"
-            type="submit"
-            variant="contained"
-            color="primary"
-            fullWidth
-          >
-            Login
-          </Button>
-          <Button
-            component={RouterLink}
-            className="register-link"
-            to="/register"
-            variant="outlined"
-            color="primary"
-            fullWidth
-          >
-            Sign up
-          </Button>
-        </form>
+
+        {loading ? (
+          <CircularProgress />
+        ) : (
+          <form onSubmit={handleSubmit}>
+            <TextField
+              label="Username or Email"
+              variant="outlined"
+              fullWidth
+              margin="normal"
+              value={identifier}
+              onChange={(e) => setIdentifier(e.target.value)}
+              autoComplete="username email"
+            />
+            <TextField
+              label="Password"
+              type="password"
+              variant="outlined"
+              fullWidth
+              margin="normal"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              autoComplete="current-password"
+            />
+            <Button
+              className="login-submit"
+              type="submit"
+              variant="contained"
+              color="primary"
+              fullWidth
+            >
+              Login
+            </Button>
+            <Button
+              component={RouterLink}
+              className="register-link"
+              to="/register"
+              variant="outlined"
+              color="primary"
+              fullWidth
+            >
+              Sign up
+            </Button>
+          </form>
+        )}
       </Box>
     </Container>
   );

--- a/frontend/src/components/auth/ProtectedRoute.jsx
+++ b/frontend/src/components/auth/ProtectedRoute.jsx
@@ -1,13 +1,19 @@
+import { useEffect } from "react";
 import CircularProgress from "@mui/material/CircularProgress";
 import { Navigate, useLocation } from "react-router-dom";
 import PropTypes from "prop-types";
 import useAuth from "../hooks/useAuth";
+import { refreshToken } from "../hooks/refreshToken";
 import { Box } from "@mui/material";
 import "./styles/auth.css";
 
 const ProtectedRoute = ({ element }) => {
   const isAuthenticated = useAuth();
   const location = useLocation();
+
+  useEffect(() => {
+    refreshToken(); // Refresh token on component mount
+  }, []);
 
   if (isAuthenticated === null) {
     return (

--- a/frontend/src/components/hooks/refreshToken.js
+++ b/frontend/src/components/hooks/refreshToken.js
@@ -1,0 +1,25 @@
+// src/utils/auth.js
+
+import axios from "axios";
+
+export const refreshToken = async () => {
+  const token = sessionStorage.getItem("token");
+
+  if (!token) {
+    console.log("No token found");
+    return;
+  }
+
+  try {
+    const response = await axios.post("/api/auth/refresh_token", {}, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+    const newToken = response.data.token;
+    sessionStorage.setItem("token", newToken);
+    console.log("Token refreshed");
+  } catch (error) {
+    console.log("Failed to refresh token", error);
+  }
+};

--- a/frontend/src/components/hooks/useAuth.js
+++ b/frontend/src/components/hooks/useAuth.js
@@ -1,5 +1,8 @@
+// src/hooks/useAuth.js
+
 import { useEffect, useState } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
+import { refreshToken } from "./refreshToken";
 
 const useAuth = () => {
   const [isAuthenticated, setIsAuthenticated] = useState(null);
@@ -7,12 +10,17 @@ const useAuth = () => {
   const location = useLocation();
 
   useEffect(() => {
-    const token = localStorage.getItem("auth");
+    const token = sessionStorage.getItem("token");
     if (token) {
       setIsAuthenticated(true);
     } else {
       setIsAuthenticated(false);
     }
+  }, []);
+
+  useEffect(() => {
+    const interval = setInterval(refreshToken, 55 * 60 * 1000); // Refresh token every 55 minutes
+    return () => clearInterval(interval);
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
This pull request introduces the following key changes to the codebase:
1. Backend:
    * Added an endpoint /refresh_token in backend/routes/auth.py to handle refreshing JWT tokens. This helps in maintaining active sessions without requiring users to re-login frequently.
    * Modified the /user endpoint to utilize the new token refresh logic.
2. Frontend:
    * Updated the Account.jsx component to improve password validation logic and user feedback.
    * Enhanced the Login.jsx component to display a loading indicator during login attempts and handle login success more smoothly by refreshing the token.
    * Added a new component ProtectedRoute.jsx that ensures token refresh on mount to maintain user session.
    * Introduced a refreshToken hook in hooks/refreshToken.js to manage token refreshing logic.
    * Updated the useAuth hook in hooks/useAuth.js to periodically refresh the token every 55 minutes.
